### PR TITLE
fix: restore v run _check.vsh to green (prefix unused params with _)

### DIFF
--- a/accessibility/backend_linux.v
+++ b/accessibility/backend_linux.v
@@ -123,7 +123,7 @@ fn (mut b LinuxAccessibilityBackend) post_notification(node_id int,
 }
 
 fn (mut b LinuxAccessibilityBackend) update_text_field(node_id int, value string,
-	selected_range Range, cursor_line int) {
+	selected_range Range, _cursor_line int) {
 	$if $pkgconfig('atk') {
 		b.ensure_init()
 

--- a/accessibility/backend_stub.v
+++ b/accessibility/backend_stub.v
@@ -5,21 +5,21 @@ module accessibility
 // when no platform backend matches.
 struct StubAccessibilityBackend {}
 
-fn (mut b StubAccessibilityBackend) update_tree(nodes map[int]AccessibilityNode, root_id int) {
+fn (mut b StubAccessibilityBackend) update_tree(_nodes map[int]AccessibilityNode, _root_id int) {
 	// Do nothing on unsupported platforms.
 }
 
-fn (mut b StubAccessibilityBackend) set_focus(node_id int) {
+fn (mut b StubAccessibilityBackend) set_focus(_node_id int) {
 	// Do nothing
 }
 
-fn (mut b StubAccessibilityBackend) post_notification(node_id int,
-	notification AccessibilityNotification) {
+fn (mut b StubAccessibilityBackend) post_notification(_node_id int,
+	_notification AccessibilityNotification) {
 	// Do nothing
 }
 
-fn (mut b StubAccessibilityBackend) update_text_field(node_id int, value string,
-	selected_range Range, cursor_line int) {
+fn (mut b StubAccessibilityBackend) update_text_field(_node_id int, _value string,
+	_selected_range Range, _cursor_line int) {
 	// Do nothing
 }
 

--- a/examples/accessibility_check.v
+++ b/examples/accessibility_check.v
@@ -39,7 +39,7 @@ fn init(mut app App) {
 	app.ts.enable_accessibility(true)
 }
 
-fn keydown(key gg.KeyCode, mod gg.Modifier, mut app App) {
+fn keydown(key gg.KeyCode, _mod gg.Modifier, mut app App) {
 	if key == .tab {
 		app.has_focus = !app.has_focus
 		println('Focus changed: ${app.has_focus}')

--- a/examples/showcase.v
+++ b/examples/showcase.v
@@ -646,7 +646,7 @@ fn (mut app ShowcaseApp) create_typography_section(width f32) {
 	app.sections << section
 }
 
-fn (mut app ShowcaseApp) create_stroke_section(width f32) {
+fn (mut app ShowcaseApp) create_stroke_section(_width f32) {
 	mut section := ShowcaseSection{
 		title:       'Text Stroke'
 		description: 'Outlined and hollow text using FreeType Stroker.'
@@ -894,7 +894,7 @@ fn (mut app ShowcaseApp) create_rich_text_section(width f32) {
 	app.sections << section
 }
 
-fn (mut app ShowcaseApp) create_i18n_section(width f32) {
+fn (mut app ShowcaseApp) create_i18n_section(_width f32) {
 	// =========================================================================
 	// Section 5: Internationalization
 	// =========================================================================
@@ -1271,7 +1271,7 @@ fn (mut app ShowcaseApp) create_direct_api_section(width f32) {
 	app.sections << section
 }
 
-fn (mut app ShowcaseApp) create_rotation_section(width f32) {
+fn (mut app ShowcaseApp) create_rotation_section(_width f32) {
 	// =========================================================================
 	// Section: Vertical Text
 	// =========================================================================

--- a/glyph_atlas.v
+++ b/glyph_atlas.v
@@ -366,7 +366,7 @@ fn (mut renderer Renderer) load_glyph(cfg LoadGlyphConfig) !CachedGlyph {
 // - FT_Get_Glyph / FT_Glyph_Stroke / FT_Glyph_To_Bitmap fails
 // - bitmap conversion or atlas insertion fails
 fn (mut renderer Renderer) load_stroked_glyph(cfg LoadGlyphConfig,
-	stroke_radius i64) !CachedGlyph {
+	_stroke_radius i64) !CachedGlyph {
 	$if profile ? {
 		start := time.sys_mono_now()
 		defer {


### PR DESCRIPTION
The verify workflow — `.agent/workflows/verify.md` → `v run _check.vsh` — runs the example checks with `v -check -N`, and `-N` promotes `unused parameter` **notices to hard errors**. On a current V there are 15 pre-existing unused-parameter sites, so `_check.vsh` fails on a clean checkout:

```
accessibility/backend_stub.v:8:49: error: unused parameter: `nodes`
...
glyph_atlas.v:369:2: error: unused parameter: `stroke_radius`
examples/showcase.v:643:48: error: unused parameter: `width`
```

This prefixes the genuinely-unused parameters with `_` (the V idiom for "intentionally unused"). **No behavioural change** — purely parameter renames:

- **`accessibility/backend_stub.v`** (9) — the stub backend is the no-op implementation selected on platforms without native accessibility, so every interface parameter is unused by design.
- **`accessibility/backend_linux.v`** (1) — only `cursor_line` is unused; `node_id`/`value`/`selected_range` still drive the atk calls.
- **`glyph_atlas.v`** (1) — `load_stroked_glyph`'s `stroke_radius` is unused (the stroke radius is configured on the `FT_Stroker`, not read here).
- **`examples/showcase.v`** (3) + **`examples/accessibility_check.v`** (1) — unused callback/section parameters.

After this change:
- `v -check -N examples/*.v` → **0** unused-parameter errors (was 11 under `-N`)
- `v test .` → **12/12 pass**
- `v check-md .` → clean

So `v run _check.vsh` goes green again on a current V.
