### PR TITLE
fix: freetype bitmap glyph cast

### DIFF
--- a/glyph_atlas.v
+++ b/glyph_atlas.v
@@ -325,7 +325,8 @@ fn (mut renderer Renderer) load_glyph(cfg LoadGlyphConfig) !CachedGlyph {
 			// - Resets glyph slot to fresh state
 			// - Produces bitmap directly (no translate/render step needed)
 			// - Same validity requirements as normal load: face + index valid
-			if C.FT_Load_Glyph(cfg.face, cfg.index, C.FT_LOAD_RENDER | C.FT_LOAD_COLOR | target_flag) != 0 {
+			if C.FT_Load_Glyph(cfg.face, cfg.index,
+				C.FT_LOAD_RENDER | C.FT_LOAD_COLOR | target_flag) != 0 {
 				return error('FT_Render_Glyph failed and fallback load failed')
 			}
 			// glyph now has bitmap directly via FT_LOAD_RENDER
@@ -414,7 +415,7 @@ fn (mut renderer Renderer) load_stroked_glyph(cfg LoadGlyphConfig,
 	}
 
 	// Cast to BitmapGlyph
-	bmp_glyph := &C.FT_BitmapGlyphRec(ft_glyph)
+	bmp_glyph := unsafe { &C.FT_BitmapGlyphRec(ft_glyph) }
 	ft_bitmap := &bmp_glyph.bitmap
 
 	if ft_bitmap.buffer == 0 || ft_bitmap.width == 0 || ft_bitmap.rows == 0 {


### PR DESCRIPTION
## Summary

This was exposed by vlang/gui CI when compiling vglyph as a dependency with `-W` on macOS.

After `FT_Glyph_To_Bitmap`, the glyph is intentionally reinterpreted as `FT_BitmapGlyphRec`. V now requires this pointer cast to be explicit `unsafe`, so this PR marks only that cast as unsafe and leaves the FreeType flow unchanged.

## Changes

- Wrap the `FT_GlyphRec` -> `FT_BitmapGlyphRec` cast in `unsafe`.
- Apply vfmt to the touched file.

## Context

This was exposed by vlang/gui CI when compiling examples with `-W` on macOS.

## Tests

```sh
v fmt -verify -inprocess glyph_atlas.v
git diff --check
v test .