### PR TITLE
fix: darwin accessibility cursor line notice

### DIFF
--- a/accessibility/backend_darwin.v
+++ b/accessibility/backend_darwin.v
@@ -161,7 +161,7 @@ fn (mut b DarwinAccessibilityBackend) post_notification(node_id int,
 }
 
 fn (mut b DarwinAccessibilityBackend) update_text_field(node_id int, value string,
-	selected_range Range, cursor_line int) {
+	selected_range Range, _cursor_line int) {
 	unsafe {
 		if node_id !in b.elements {
 			return


### PR DESCRIPTION
## Summary

Silences the repeated macOS notice from the Darwin accessibility backend by marking the unused cursor line parameter as intentionally unused.

This keeps the same method signature shape and does not change behavior. Linux and stub backends already use the same `_cursor_line` convention.

## Tests

```sh
git diff --check
v fmt -verify -inprocess accessibility/backend_darwin.v
v -shared -check accessibility
v -os macos -shared -check accessibility
```