### PR TITLE
text: add baseline rise support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ concurrency:
 
 env:
   CORE_PKG_CONFIG_MODULES: freetype2 harfbuzz fribidi fontconfig pango pangoft2 gobject-2.0 glib-2.0
+  V_VERSION: ddc9c99fda9b46d4a1e3d8fe674a4395bb311d96
 
 jobs:
   linux:
@@ -51,7 +52,7 @@ jobs:
       - name: Install V
         uses: vlang/setup-v@v1.4
         with:
-          check-latest: true
+          version: ${{ env.V_VERSION }}
 
       - name: Log V version
         run: v version
@@ -158,7 +159,7 @@ jobs:
       - name: Install V
         uses: vlang/setup-v@v1.4
         with:
-          check-latest: true
+          version: ${{ env.V_VERSION }}
 
       - name: Log V version
         run: v version
@@ -185,7 +186,7 @@ jobs:
             echo "[$test_index/${#test_files[@]}] $file"
             test_index=$((test_index + 1))
           done
-          VJOBS=1 v -no-parallel test "${test_files[@]}"
+          VJOBS=1 v -no-parallel -cc clang test "${test_files[@]}"
 
       - name: Compile examples
         run: |
@@ -206,7 +207,7 @@ jobs:
           for file in "${example_files[@]}"; do
             echo "[$example_index/${#example_files[@]}] $file"
             VMODULES="$RUNNER_TEMP/vglyph-vmodules" \
-              v -no-parallel -path "@vlib|@vmodules|." \
+              v -no-parallel -cc clang -path "@vlib|@vmodules|." \
               -o "$RUNNER_TEMP/vglyph-example-bin/$(basename "${file%.v}")" \
               "$file"
             example_index=$((example_index + 1))
@@ -232,7 +233,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $revision = (git ls-remote https://github.com/vlang/v HEAD).Split()[0]
+          $revision = '${{ env.V_VERSION }}'
           "revision=$revision" | Add-Content -Path $env:GITHUB_OUTPUT
 
       - name: Restore V compiler cache

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ pacman -S mingw-w64-x86_64-pango mingw-w64-x86_64-freetype
 Use the `TextSystem` for the easiest integration. It handles initialization,
 caching, and rendering.
 
-```v
+```v oksyntax
 import vglyph
 import gg
 

--- a/_api_test.v
+++ b/_api_test.v
@@ -119,6 +119,35 @@ fn test_get_cache_key_diff_typeface() {
 	assert key1 != key2
 }
 
+fn test_get_cache_key_diff_rise() {
+	mut ctx := new_context(1.0)!
+	defer { ctx.free() }
+	mut ts := TextSystem{
+		ctx:             ctx
+		renderer:        unsafe { nil }
+		font_hash_cache: map[string]u64{}
+		am:              unsafe { nil }
+	}
+
+	cfg1 := TextConfig{
+		style: TextStyle{
+			font_name: 'Arial 12'
+		}
+	}
+
+	cfg2 := TextConfig{
+		style: TextStyle{
+			font_name: 'Arial 12'
+			rise:      4
+		}
+	}
+
+	key1 := ts.get_cache_key('hello', cfg1)
+	key2 := ts.get_cache_key('hello', cfg2)
+
+	assert key1 != key2
+}
+
 // ============================================================================
 // API-level validation integration tests (SEC-01, SEC-02, SEC-03)
 // ============================================================================

--- a/_rise_test.v
+++ b/_rise_test.v
@@ -1,0 +1,720 @@
+module vglyph
+
+import gg
+
+// Regression coverage for the typed TextStyle.rise baseline-shift primitive.
+
+const rise_test_font = 'Roboto Flex 24'
+const rise_test_font_path = '${@DIR}/assets/RobotoFlex.ttf'
+const rise_selection_tolerance = f32(0.75)
+
+fn new_rise_test_context() !&Context {
+	mut ctx := new_context(1.0)!
+	ctx.add_font_file(rise_test_font_path) or {
+		ctx.free()
+		return error('failed to load rise test font ${rise_test_font_path}: ${err}')
+	}
+	return ctx
+}
+
+fn f64_abs(v f64) f64 {
+	return if v < 0 { -v } else { v }
+}
+
+fn item_for_index(layout Layout, index int) ?Item {
+	for item in layout.items {
+		if index >= item.start_index && index < item.start_index + item.length {
+			return item
+		}
+	}
+	return none
+}
+
+fn char_rect_for_index(layout Layout, index int) ?CharRect {
+	for rect in layout.char_rects {
+		if rect.index == index {
+			return rect
+		}
+	}
+	return none
+}
+
+fn line_for_index(layout Layout, index int) ?Line {
+	for line in layout.lines {
+		if index >= line.start_index && index < line.start_index + line.length {
+			return line
+		}
+	}
+	return none
+}
+
+fn assert_rect_contains_rect(outer gg.Rect, inner gg.Rect, label string) {
+	assert outer.x <= inner.x + rise_selection_tolerance, '${label} left edge should contain rect'
+	assert outer.x + outer.width + rise_selection_tolerance >= inner.x + inner.width, '${label} right edge should contain rect'
+	assert outer.y <= inner.y + rise_selection_tolerance, '${label} top edge should contain rect'
+	assert outer.y + outer.height + rise_selection_tolerance >= inner.y + inner.height, '${label} bottom edge should contain rect'
+}
+
+fn assert_hit_test_center(layout Layout, rect gg.Rect, index int, label string) {
+	center_x := rect.x + rect.width / 2
+	center_y := rect.y + rect.height / 2
+	assert layout.hit_test(center_x, center_y) == index, '${label} hit-test center should resolve to byte index'
+}
+
+fn assert_selection_contains_rect(selection gg.Rect, rect gg.Rect, label string) {
+	assert selection.x <= rect.x + rise_selection_tolerance, '${label} selection left should cover char rect'
+	assert selection.x + selection.width + rise_selection_tolerance >= rect.x + rect.width, '${label} selection right should cover char rect'
+	assert selection.y <= rect.y + rise_selection_tolerance, '${label} selection top should cover char rect'
+	assert selection.y + selection.height + rise_selection_tolerance >= rect.y + rect.height, '${label} selection bottom should cover char rect'
+}
+
+fn test_plain_text_rise_moves_base_style_run() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	base := ctx.layout_text('A', TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+		}
+	})!
+	raised := ctx.layout_text('A', TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+			rise:      8
+		}
+	})!
+	lowered := ctx.layout_text('A', TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+			rise:      -6
+		}
+	})!
+
+	assert base.items.len > 0
+	assert raised.items.len > 0
+	assert lowered.items.len > 0
+
+	assert raised.items[0].y < base.items[0].y, 'base TextConfig.style positive rise should move the run baseline up'
+	assert lowered.items[0].y > base.items[0].y, 'base TextConfig.style negative rise should move the run baseline down'
+
+	base_rect := char_rect_for_index(base, 0) or {
+		assert false, 'base char rect missing'
+		return
+	}
+	raised_rect := char_rect_for_index(raised, 0) or {
+		assert false, 'raised char rect missing'
+		return
+	}
+	lowered_rect := char_rect_for_index(lowered, 0) or {
+		assert false, 'lowered char rect missing'
+		return
+	}
+	assert raised_rect.rect.y < base_rect.rect.y, 'base TextConfig.style positive rise should move hit geometry up'
+	assert lowered_rect.rect.y > base_rect.rect.y, 'base TextConfig.style negative rise should move hit geometry down'
+	raised_item_delta := base.items[0].y - raised.items[0].y
+	lowered_item_delta := lowered.items[0].y - base.items[0].y
+	raised_rect_delta := f64(base_rect.rect.y - raised_rect.rect.y)
+	lowered_rect_delta := f64(lowered_rect.rect.y - base_rect.rect.y)
+	assert raised_item_delta > 6.0, 'positive rise should move item baseline by roughly one rise'
+	assert raised_item_delta < 10.0, 'positive rise should not be applied twice to item baseline'
+	assert lowered_item_delta > 4.0, 'negative rise should move item baseline by roughly one rise'
+	assert lowered_item_delta < 8.0, 'negative rise should not be applied twice to item baseline'
+	assert raised_rect_delta > 6.0, 'positive rise should move hit geometry by roughly one rise'
+	assert raised_rect_delta < 10.0, 'positive rise should not be applied twice to hit geometry'
+	assert lowered_rect_delta > 4.0, 'negative rise should move hit geometry by roughly one rise'
+	assert lowered_rect_delta < 8.0, 'negative rise should not be applied twice to hit geometry'
+	assert f64_abs(raised_item_delta - raised_rect_delta) <= 1.0, 'item and hit geometry rise should stay coherent'
+	assert f64_abs(lowered_item_delta - lowered_rect_delta) <= 1.0, 'lowered item and hit geometry rise should stay coherent'
+
+	raised_cursor := raised.get_cursor_pos(0) or {
+		assert false, 'raised cursor geometry missing'
+		return
+	}
+	assert raised_cursor.y == raised_rect.rect.y
+	assert raised_cursor.height == raised_rect.rect.height
+
+	lowered_cursor := lowered.get_cursor_pos(0) or {
+		assert false, 'lowered cursor geometry missing'
+		return
+	}
+	assert lowered_cursor.y == lowered_rect.rect.y
+	assert lowered_cursor.height == lowered_rect.rect.height
+
+	raised_selection := raised.get_selection_rects(0, 1)
+	assert raised_selection.len > 0, 'raised selection geometry missing'
+	assert_selection_contains_rect(raised_selection[0], raised_rect.rect, 'raised base-style')
+
+	lowered_selection := lowered.get_selection_rects(0, 1)
+	assert lowered_selection.len > 0, 'lowered selection geometry missing'
+	assert_selection_contains_rect(lowered_selection[0], lowered_rect.rect, 'lowered base-style')
+
+	assert_hit_test_center(base, base_rect.rect, 0, 'base-style plain')
+	assert_hit_test_center(raised, raised_rect.rect, 0, 'base-style raised')
+	assert_hit_test_center(lowered, lowered_rect.rect, 0, 'base-style lowered')
+}
+
+fn test_rich_text_rise_moves_run_geometry() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	plain := ctx.layout_text('ABC', TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+		}
+	})!
+
+	rt := RichText{
+		runs: [
+			StyleRun{
+				text: 'A'
+			},
+			StyleRun{
+				text:  'B'
+				style: TextStyle{
+					rise: 8
+				}
+			},
+			StyleRun{
+				text:  'C'
+				style: TextStyle{
+					rise: -6
+				}
+			},
+		]
+	}
+
+	layout := ctx.layout_rich_text(rt, TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+		}
+	})!
+
+	base_item := item_for_index(layout, 0) or {
+		assert false, 'base run item missing'
+		return
+	}
+	raised_item := item_for_index(layout, 1) or {
+		assert false, 'raised run item missing'
+		return
+	}
+	lowered_item := item_for_index(layout, 2) or {
+		assert false, 'lowered run item missing'
+		return
+	}
+
+	assert raised_item.y < base_item.y, 'positive rise should move the run baseline up'
+	assert lowered_item.y > base_item.y, 'negative rise should move the run baseline down'
+
+	plain_base_item := item_for_index(plain, 0) or {
+		assert false, 'plain base run item missing'
+		return
+	}
+	assert f64_abs(base_item.y - plain_base_item.y) <= 1.0, 'unraised run in a mixed-rise line should stay on the plain baseline'
+
+	base_rect := char_rect_for_index(layout, 0) or {
+		assert false, 'base char rect missing'
+		return
+	}
+	raised_rect := char_rect_for_index(layout, 1) or {
+		assert false, 'raised char rect missing'
+		return
+	}
+	lowered_rect := char_rect_for_index(layout, 2) or {
+		assert false, 'lowered char rect missing'
+		return
+	}
+
+	assert raised_rect.rect.y < base_rect.rect.y, 'positive rise should move hit geometry up'
+	assert lowered_rect.rect.y > base_rect.rect.y, 'negative rise should move hit geometry down'
+	assert_hit_test_center(layout, base_rect.rect, 0, 'mixed-rise base')
+	assert_hit_test_center(layout, raised_rect.rect, 1, 'mixed-rise raised')
+	assert_hit_test_center(layout, lowered_rect.rect, 2, 'mixed-rise lowered')
+
+	plain_base_rect := char_rect_for_index(plain, 0) or {
+		assert false, 'plain base char rect missing'
+		return
+	}
+	assert f64_abs(f64(base_rect.rect.y - plain_base_rect.rect.y)) <= 1.0, 'unraised run hit geometry should stay on the plain baseline'
+
+	line := line_for_index(layout, 0) or {
+		assert false, 'mixed-rise line geometry missing'
+		return
+	}
+	assert_rect_contains_rect(line.rect, base_rect.rect, 'mixed-rise line/base')
+	assert_rect_contains_rect(line.rect, raised_rect.rect, 'mixed-rise line/raised')
+	assert_rect_contains_rect(line.rect, lowered_rect.rect, 'mixed-rise line/lowered')
+
+	raised_cursor := layout.get_cursor_pos(1) or {
+		assert false, 'raised cursor geometry missing'
+		return
+	}
+	assert raised_cursor.y == raised_rect.rect.y
+	assert raised_cursor.height == raised_rect.rect.height
+
+	raised_selection := layout.get_selection_rects(1, 2)
+	assert raised_selection.len > 0, 'raised selection geometry missing'
+	assert_selection_contains_rect(raised_selection[0], raised_rect.rect, 'raised')
+
+	cross_run_selection := layout.get_selection_rects(0, 3)
+	assert cross_run_selection.len > 0, 'cross-run selection geometry missing'
+	assert_selection_contains_rect(cross_run_selection[0], base_rect.rect, 'cross-run base')
+	assert_selection_contains_rect(cross_run_selection[0], raised_rect.rect, 'cross-run raised')
+	assert_selection_contains_rect(cross_run_selection[0], lowered_rect.rect, 'cross-run lowered')
+
+	end_cursor := layout.get_cursor_pos(3) or {
+		assert false, 'mixed-rise end cursor geometry missing'
+		return
+	}
+	assert end_cursor.y == line.rect.y
+	assert end_cursor.height == line.rect.height
+}
+
+fn test_multiline_rise_stays_on_own_line_geometry() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	text := 'AB\nCD'
+	plain := ctx.layout_text(text, TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+		}
+	})!
+	layout := ctx.layout_rich_text(RichText{
+		runs: [
+			StyleRun{
+				text: 'A'
+			},
+			StyleRun{
+				text:  'B'
+				style: TextStyle{
+					rise: 8
+				}
+			},
+			StyleRun{
+				text: '\nCD'
+			},
+		]
+	}, TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+		}
+	})!
+
+	assert layout.lines.len == 2, 'explicit newline should produce two lines'
+
+	first_line := line_for_index(layout, 0) or {
+		assert false, 'first line geometry missing'
+		return
+	}
+	second_line := line_for_index(layout, 3) or {
+		assert false, 'second line geometry missing'
+		return
+	}
+	assert second_line.rect.y > first_line.rect.y, 'second line should stay below the raised first line'
+
+	first_base_rect := char_rect_for_index(layout, 0) or {
+		assert false, 'first line base char rect missing'
+		return
+	}
+	first_raised_rect := char_rect_for_index(layout, 1) or {
+		assert false, 'first line raised char rect missing'
+		return
+	}
+	second_c_rect := char_rect_for_index(layout, 3) or {
+		assert false, 'second line C char rect missing'
+		return
+	}
+	second_d_rect := char_rect_for_index(layout, 4) or {
+		assert false, 'second line D char rect missing'
+		return
+	}
+	assert first_raised_rect.rect.y < first_base_rect.rect.y, 'rise should move only the first line run up'
+	assert_rect_contains_rect(first_line.rect, first_base_rect.rect, 'first line/base')
+	assert_rect_contains_rect(first_line.rect, first_raised_rect.rect, 'first line/raised')
+	assert_rect_contains_rect(second_line.rect, second_c_rect.rect, 'second line/C')
+	assert_rect_contains_rect(second_line.rect, second_d_rect.rect, 'second line/D')
+	assert_hit_test_center(layout, first_base_rect.rect, 0, 'multiline base')
+	assert_hit_test_center(layout, first_raised_rect.rect, 1, 'multiline raised')
+	assert_hit_test_center(layout, second_c_rect.rect, 3, 'multiline second C')
+	assert_hit_test_center(layout, second_d_rect.rect, 4, 'multiline second D')
+
+	plain_second_line := line_for_index(plain, 3) or {
+		assert false, 'plain second line geometry missing'
+		return
+	}
+	plain_second_c_rect := char_rect_for_index(plain, 3) or {
+		assert false, 'plain second line C char rect missing'
+		return
+	}
+	second_line_offset := f64(second_c_rect.rect.y - second_line.rect.y)
+	plain_second_line_offset := f64(plain_second_c_rect.rect.y - plain_second_line.rect.y)
+	assert f64_abs(second_line_offset - plain_second_line_offset) <= 1.0, 'rise from first line should not change second-line internal geometry'
+
+	first_selection := layout.get_selection_rects(0, 2)
+	assert first_selection.len == 1, 'first-line selection should stay on one line'
+	assert_selection_contains_rect(first_selection[0], first_base_rect.rect,
+		'first-line selection/base')
+	assert_selection_contains_rect(first_selection[0], first_raised_rect.rect,
+		'first-line selection/raised')
+
+	second_selection := layout.get_selection_rects(3, 5)
+	assert second_selection.len == 1, 'second-line selection should stay on one line'
+	assert_selection_contains_rect(second_selection[0], second_c_rect.rect,
+		'second-line selection/C')
+	assert_selection_contains_rect(second_selection[0], second_d_rect.rect,
+		'second-line selection/D')
+
+	cross_line_selection := layout.get_selection_rects(0, 5)
+	assert cross_line_selection.len == 2, 'cross-line selection should produce one rect per line'
+	assert_selection_contains_rect(cross_line_selection[0], first_base_rect.rect,
+		'cross-line first/base')
+	assert_selection_contains_rect(cross_line_selection[0], first_raised_rect.rect,
+		'cross-line first/raised')
+	assert_selection_contains_rect(cross_line_selection[1], second_c_rect.rect,
+		'cross-line second/C')
+	assert_selection_contains_rect(cross_line_selection[1], second_d_rect.rect,
+		'cross-line second/D')
+
+	end_cursor := layout.get_cursor_pos(text.len) or {
+		assert false, 'multiline end cursor geometry missing'
+		return
+	}
+	assert end_cursor.y == second_line.rect.y
+	assert end_cursor.height == second_line.rect.height
+}
+
+fn test_rich_text_rise_adds_to_base_style_rise() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	layout := ctx.layout_rich_text(RichText{
+		runs: [
+			StyleRun{
+				text: 'A'
+			},
+			StyleRun{
+				text:  'A'
+				style: TextStyle{
+					rise: 7
+				}
+			},
+		]
+	}, TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+			rise:      5
+		}
+	})!
+
+	base_item := item_for_index(layout, 0) or {
+		assert false, 'base run item missing'
+		return
+	}
+	raised_item := item_for_index(layout, 1) or {
+		assert false, 'raised run item missing'
+		return
+	}
+
+	delta := base_item.y - raised_item.y
+	assert delta > 4.5, 'run rise should add to base rise instead of replacing it'
+	assert delta < 9.5, 'run rise delta should remain bounded near the per-run rise'
+
+	base_rect := char_rect_for_index(layout, 0) or {
+		assert false, 'base char rect missing'
+		return
+	}
+	raised_rect := char_rect_for_index(layout, 1) or {
+		assert false, 'raised char rect missing'
+		return
+	}
+	rect_delta := base_rect.rect.y - raised_rect.rect.y
+	assert rect_delta > 4.5, 'cumulative run rise should move hit geometry up'
+	assert rect_delta < 9.5, 'cumulative run rise hit geometry should remain bounded near the per-run rise'
+
+	raised_cursor := layout.get_cursor_pos(1) or {
+		assert false, 'raised cursor geometry missing'
+		return
+	}
+	assert raised_cursor.y == raised_rect.rect.y
+	assert raised_cursor.height == raised_rect.rect.height
+
+	raised_selection := layout.get_selection_rects(1, 2)
+	assert raised_selection.len > 0, 'raised cumulative selection geometry missing'
+	assert_selection_contains_rect(raised_selection[0], raised_rect.rect, 'raised cumulative')
+}
+
+fn test_rich_text_run_rise_can_cancel_base_style_rise() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	layout := ctx.layout_rich_text(RichText{
+		runs: [
+			StyleRun{
+				text: 'A'
+			},
+			StyleRun{
+				text:  'A'
+				style: TextStyle{
+					rise: -5
+				}
+			},
+		]
+	}, TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+			rise:      5
+		}
+	})!
+
+	base_item := item_for_index(layout, 0) or {
+		assert false, 'base run item missing'
+		return
+	}
+	cancelled_item := item_for_index(layout, 1) or {
+		assert false, 'cancelled run item missing'
+		return
+	}
+
+	delta := cancelled_item.y - base_item.y
+	assert delta > 3.5, 'run rise should be able to cancel base rise'
+	assert delta < 6.5, 'cancelled rise delta should stay near the base rise'
+
+	base_rect := char_rect_for_index(layout, 0) or {
+		assert false, 'base char rect missing'
+		return
+	}
+	cancelled_rect := char_rect_for_index(layout, 1) or {
+		assert false, 'cancelled char rect missing'
+		return
+	}
+	rect_delta := cancelled_rect.rect.y - base_rect.rect.y
+	assert rect_delta > 3.5, 'cancelled run rise should lower hit geometry relative to base rise'
+	assert rect_delta < 6.5, 'cancelled run hit geometry delta should stay near the base rise'
+
+	cancelled_cursor := layout.get_cursor_pos(1) or {
+		assert false, 'cancelled cursor geometry missing'
+		return
+	}
+	assert cancelled_cursor.y == cancelled_rect.rect.y
+	assert cancelled_cursor.height == cancelled_rect.rect.height
+
+	cancelled_selection := layout.get_selection_rects(1, 2)
+	assert cancelled_selection.len > 0, 'cancelled selection geometry missing'
+	assert_selection_contains_rect(cancelled_selection[0], cancelled_rect.rect, 'cancelled')
+}
+
+fn test_markup_rise_adds_to_base_style_rise() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	plain := ctx.layout_text('AB', TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+		}
+	})!
+	layout := ctx.layout_text('A<span rise="7168">B</span>', TextConfig{
+		style:      TextStyle{
+			font_name: rise_test_font
+			rise:      5
+		}
+		use_markup: true
+	})!
+
+	plain_a_rect := char_rect_for_index(plain, 0) or {
+		assert false, 'plain A char rect missing'
+		return
+	}
+	plain_b_rect := char_rect_for_index(plain, 1) or {
+		assert false, 'plain B char rect missing'
+		return
+	}
+	markup_a_rect := char_rect_for_index(layout, 0) or {
+		assert false, 'markup A char rect missing'
+		return
+	}
+	markup_b_rect := char_rect_for_index(layout, 1) or {
+		assert false, 'markup B char rect missing'
+		return
+	}
+
+	base_delta := f64(plain_a_rect.rect.y - markup_a_rect.rect.y)
+	span_delta := f64(plain_b_rect.rect.y - markup_b_rect.rect.y)
+	run_delta := f64(markup_a_rect.rect.y - markup_b_rect.rect.y)
+	assert base_delta > 3.5, 'base TextConfig.style rise should apply in markup layout'
+	assert base_delta < 6.5, 'base markup rise delta should stay near the base rise'
+	assert span_delta > 10.0, 'markup span rise should add to the base rise'
+	assert span_delta < 14.0, 'markup span rise should not replace or double the base rise'
+	assert run_delta > 5.5, 'markup span should remain raised relative to the base run'
+	assert run_delta < 8.5, 'markup span relative rise should stay near the span rise'
+
+	markup_b_cursor := layout.get_cursor_pos(1) or {
+		assert false, 'markup B cursor geometry missing'
+		return
+	}
+	assert markup_b_cursor.y == markup_b_rect.rect.y
+	assert markup_b_cursor.height == markup_b_rect.rect.height
+
+	markup_b_selection := layout.get_selection_rects(1, 2)
+	assert markup_b_selection.len > 0, 'markup B selection geometry missing'
+	assert_selection_contains_rect(markup_b_selection[0], markup_b_rect.rect, 'markup B')
+}
+
+fn test_markup_rise_recomposition_preserves_attrs_and_spacing() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	markup := 'A<span foreground="#112233" background="#445566" underline="single" rise="2048">B</span>'
+	unspaced := ctx.layout_text(markup, TextConfig{
+		style:      TextStyle{
+			font_name: rise_test_font
+			rise:      5
+		}
+		use_markup: true
+	})!
+	spaced := ctx.layout_text(markup, TextConfig{
+		style:      TextStyle{
+			font_name:      rise_test_font
+			letter_spacing: 10
+			rise:           5
+		}
+		use_markup: true
+	})!
+
+	spaced_b := item_for_index(spaced, 1) or {
+		assert false, 'styled markup B item missing'
+		return
+	}
+	assert spaced_b.color.r == 17
+	assert spaced_b.color.g == 34
+	assert spaced_b.color.b == 51
+	assert spaced_b.color.a == 255
+	assert spaced_b.has_bg_color
+	assert spaced_b.bg_color.r == 68
+	assert spaced_b.bg_color.g == 85
+	assert spaced_b.bg_color.b == 102
+	assert spaced_b.bg_color.a == 255
+	assert spaced_b.has_underline
+
+	unspaced_a := item_for_index(unspaced, 0) or {
+		assert false, 'unspaced markup A item missing'
+		return
+	}
+	unspaced_b := item_for_index(unspaced, 1) or {
+		assert false, 'unspaced markup B item missing'
+		return
+	}
+	spaced_a := item_for_index(spaced, 0) or {
+		assert false, 'spaced markup A item missing'
+		return
+	}
+	unspaced_gap := unspaced_b.x - unspaced_a.x
+	spaced_gap := spaced_b.x - spaced_a.x
+	assert spaced_gap > unspaced_gap + 1.0, 'base letter spacing should survive markup rise attr recomposition'
+}
+
+fn test_markup_layout_rejects_embedded_nul_before_rise_composition() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	nul_markup := [u8(`A`), 0, u8(`B`)].bytestr()
+	ctx.layout_text(nul_markup, TextConfig{
+		style:      TextStyle{
+			font_name: rise_test_font
+			rise:      5
+		}
+		use_markup: true
+	}) or {
+		assert err.msg().contains('NUL byte')
+		return
+	}
+	assert false, 'markup text with embedded NUL should be rejected before Pango length lookup'
+}
+
+fn test_utf8_rise_hit_test_uses_byte_indices() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	layout := ctx.layout_rich_text(RichText{
+		runs: [
+			StyleRun{
+				text: 'A'
+			},
+			StyleRun{
+				text:  'é'
+				style: TextStyle{
+					rise: 8
+				}
+			},
+			StyleRun{
+				text: 'B'
+			},
+		]
+	}, TextConfig{
+		style: TextStyle{
+			font_name: rise_test_font
+		}
+	})!
+
+	base_rect := char_rect_for_index(layout, 0) or {
+		assert false, 'UTF-8 base char rect missing'
+		return
+	}
+	raised_rect := char_rect_for_index(layout, 1) or {
+		assert false, 'UTF-8 raised char rect missing'
+		return
+	}
+	trailing_rect := char_rect_for_index(layout, 3) or {
+		assert false, 'UTF-8 trailing char rect missing'
+		return
+	}
+	assert_hit_test_center(layout, base_rect.rect, 0, 'UTF-8 base')
+	assert_hit_test_center(layout, raised_rect.rect, 1, 'UTF-8 raised')
+	assert_hit_test_center(layout, trailing_rect.rect, 3, 'UTF-8 trailing')
+
+	line := line_for_index(layout, 1) or {
+		assert false, 'UTF-8 mixed-rise line missing'
+		return
+	}
+	assert_rect_contains_rect(line.rect, base_rect.rect, 'UTF-8 line/base')
+	assert_rect_contains_rect(line.rect, raised_rect.rect, 'UTF-8 line/raised')
+	assert_rect_contains_rect(line.rect, trailing_rect.rect, 'UTF-8 line/trailing')
+
+	end_cursor := layout.get_cursor_pos(4) or {
+		assert false, 'UTF-8 end cursor geometry missing'
+		return
+	}
+	assert end_cursor.y == line.rect.y
+	assert end_cursor.height == line.rect.height
+
+	selection := layout.get_selection_rects(0, 4)
+	assert selection.len > 0, 'UTF-8 cross-run selection geometry missing'
+	assert_selection_contains_rect(selection[0], base_rect.rect, 'UTF-8 selection/base')
+	assert_selection_contains_rect(selection[0], raised_rect.rect, 'UTF-8 selection/raised')
+	assert_selection_contains_rect(selection[0], trailing_rect.rect, 'UTF-8 selection/trailing')
+}
+
+fn test_vertical_rise_moves_visual_y_without_column_x_shift() {
+	mut ctx := new_rise_test_context()!
+	defer { ctx.free() }
+
+	base := ctx.layout_text('A', TextConfig{
+		style:       TextStyle{
+			font_name: rise_test_font
+		}
+		orientation: .vertical
+	})!
+	raised := ctx.layout_text('A', TextConfig{
+		style:       TextStyle{
+			font_name: rise_test_font
+			rise:      8
+		}
+		orientation: .vertical
+	})!
+
+	assert base.items.len > 0
+	assert raised.items.len > 0
+	assert f64_abs(raised.items[0].x - base.items[0].x) <= 0.5, 'vertical rise must not shift the column X position'
+	vertical_delta := base.items[0].y - raised.items[0].y
+	assert vertical_delta > 6.0, 'vertical positive rise should move the visual run up on Y'
+	assert vertical_delta < 10.0, 'vertical positive rise should not be applied twice on Y'
+}

--- a/api.v
+++ b/api.v
@@ -744,6 +744,7 @@ fn (mut ts TextSystem) get_cache_key(text string, cfg &TextConfig) u64 {
 	hash = fnv_hash_color(hash, cfg.style.color)
 	hash = fnv_hash_color(hash, cfg.style.bg_color)
 	hash = fnv_hash_f32(hash, cfg.style.letter_spacing)
+	hash = fnv_hash_f32(hash, cfg.style.rise)
 	hash = fnv_hash_f32(hash, cfg.style.stroke_width)
 	hash = fnv_hash_color(hash, cfg.style.stroke_color)
 

--- a/c_bindings.v
+++ b/c_bindings.v
@@ -270,6 +270,7 @@ pub type GCallback = fn ()
 
 fn C.g_object_unref(obj voidptr)
 fn C.g_object_ref(obj voidptr) voidptr
+fn C.g_slist_free(list &C.GSList)
 
 // Pango Types
 @[typedef]
@@ -382,6 +383,9 @@ pub struct C.PangoFont {}
 
 @[typedef]
 pub struct C.PangoLayoutIter {}
+
+@[typedef]
+pub struct C.PangoAttrIterator {}
 
 @[typedef]
 pub struct C.PangoLayoutLine {
@@ -507,9 +511,10 @@ pub enum PangoAttrType {
 	pango_attr_background     = 10
 	pango_attr_underline      = 11
 	pango_attr_strikethrough  = 12
-	pango_attr_letter_spacing = 13
+	pango_attr_rise           = 13
 	pango_attr_shape          = 14
-	pango_attr_font_features  = 25
+	pango_attr_letter_spacing = 17
+	pango_attr_font_features  = 23
 }
 
 pub enum PangoUnderline {
@@ -588,6 +593,7 @@ fn C.pango_layout_set_text(&C.PangoLayout, &char, int)
 fn C.pango_layout_set_markup(&C.PangoLayout, &char, int)
 fn C.pango_layout_set_font_description(&C.PangoLayout, &C.PangoFontDescription)
 fn C.pango_layout_get_iter(&C.PangoLayout) &C.PangoLayoutIter
+fn C.pango_layout_get_text(&C.PangoLayout) &char
 fn C.pango_layout_get_font_description(&C.PangoLayout) &C.PangoFontDescription
 fn C.pango_layout_get_extents(&C.PangoLayout, &C.PangoRectangle, &C.PangoRectangle)
 fn C.pango_layout_index_to_pos(&C.PangoLayout, int, &C.PangoRectangle)
@@ -700,13 +706,21 @@ fn C.pango_attr_list_insert(&C.PangoAttrList, &C.PangoAttribute)
 fn C.pango_layout_set_attributes(&C.PangoLayout, &C.PangoAttrList)
 fn C.pango_layout_get_attributes(&C.PangoLayout) &C.PangoAttrList
 fn C.pango_layout_get_line_count(&C.PangoLayout) int
+fn C.pango_attr_list_get_iterator(&C.PangoAttrList) &C.PangoAttrIterator
+fn C.pango_attr_iterator_range(&C.PangoAttrIterator, &int, &int)
+fn C.pango_attr_iterator_next(&C.PangoAttrIterator) bool
+fn C.pango_attr_iterator_destroy(&C.PangoAttrIterator)
+fn C.pango_attr_iterator_get_attrs(&C.PangoAttrIterator) &C.GSList
 
 // Pango Attribute Constructors
 fn C.pango_attr_list_copy(&C.PangoAttrList) &C.PangoAttrList
+fn C.pango_attribute_copy(&C.PangoAttribute) &C.PangoAttribute
+fn C.pango_attribute_destroy(&C.PangoAttribute)
 fn C.pango_attr_foreground_new(u16, u16, u16) &C.PangoAttribute
 fn C.pango_attr_background_new(u16, u16, u16) &C.PangoAttribute
 fn C.pango_attr_underline_new(PangoUnderline) &C.PangoAttribute
 fn C.pango_attr_strikethrough_new(bool) &C.PangoAttribute
+fn C.pango_attr_rise_new(int) &C.PangoAttribute
 fn C.pango_attr_font_features_new(&char) &C.PangoAttribute
 fn C.pango_attr_font_desc_new(&C.PangoFontDescription) &C.PangoAttribute
 fn C.pango_attr_letter_spacing_new(int) &C.PangoAttribute

--- a/docs/API.md
+++ b/docs/API.md
@@ -219,8 +219,11 @@ Defines character-level styling attributes.
 | `bg_color`          | `gg.Color`       | `transparent` | Background color (highlight).                        |
 | `underline`         | `bool`           | `false`       | Draw a single underline.                             |
 | `strikethrough`     | `bool`           | `false`       | Draw a strikethrough line.                           |
+| `rise`              | `f32`            | `0.0`         | Baseline shift in logical pixels; positive moves text up. |
 | `features`          | `&FontFeatures`  | `nil`         | Advanced typography settings.                        |
 | `object`            | `&InlineObject`  | `nil`         | Inline object definition (reserved space).           |
+
+Run-level `rise` values are cumulative with the base `TextConfig.style.rise`.
 
 ## Typeface
 

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -129,6 +129,31 @@ to physical device pixels automatically.
 
 ## Advanced Typography
 
+### Baseline Rise
+
+Use `TextStyle.rise` to shift a plain or rich-text run above or below the line
+baseline without changing the underlying text. Positive values move text up;
+negative values move it down. For superscripts and subscripts, combine `rise`
+with a smaller `size`; OpenType `sups`/`subs` can still be enabled as an
+optional glyph-substitution enhancement when the font supports it. In rich text,
+the run's `style.rise` is added to the base `TextConfig.style.rise`, so a base
+rise and a run-specific rise are cumulative.
+
+```okfmt
+rt := vglyph.RichText{
+    runs: [
+        vglyph.StyleRun{ text: 'E = mc' },
+        vglyph.StyleRun{
+            text: '2'
+            style: vglyph.TextStyle{
+                size: 14
+                rise: 8
+            }
+        },
+    ]
+}
+```
+
 ### Tab Stops
 
 By default, tab characters (`\t`) advance to the next 8-space multiple. You can

--- a/examples/showcase.v
+++ b/examples/showcase.v
@@ -5,7 +5,7 @@
 // - Layout (wrapping, alignment, hanging indents)
 // - Rich text and markup
 // - Internationalization (complex scripts, emoji)
-// - OpenType features (variable fonts, subscripts)
+// - OpenType features and baseline rise (variable fonts, subscripts)
 // - Gradient text (horizontal and vertical)
 // - Text on a path (curved/arc placement)
 // - Subpixel rendering and hit testing
@@ -249,7 +249,7 @@ fn (mut app ShowcaseApp) create_typography_section(width f32) {
 	// =========================================================================
 	mut section := ShowcaseSection{
 		title:       'Typography Essentials'
-		description: 'Full control over font families, weights, and styles.'
+		description: 'Full control over font families, weights, styles, and baseline rise.'
 	}
 
 	// Font Families
@@ -441,7 +441,7 @@ fn (mut app ShowcaseApp) create_typography_section(width f32) {
 	// ---------------------------------------------------------------------
 	// Advanced Positioning (Scripting)
 	// ---------------------------------------------------------------------
-	section.layouts << app.ts.layout_text('✨ Subscripts & Superscripts (via OpenType)', vglyph.TextConfig{
+	section.layouts << app.ts.layout_text('✨ Subscripts & Superscripts (rise + OpenType)', vglyph.TextConfig{
 		style: vglyph.TextStyle{
 			font_name: 'Sans Bold 20'
 			color:     gg.Color{200, 200, 255, 255}
@@ -464,6 +464,8 @@ fn (mut app ShowcaseApp) create_typography_section(width f32) {
 		style: vglyph.TextStyle{
 			font_name: 'Sans 24'
 			color:     color_text
+			size:      24
+			rise:      -4
 			features:  &vglyph.FontFeatures{
 				opentype_features: [
 					vglyph.FontFeature{
@@ -487,6 +489,8 @@ fn (mut app ShowcaseApp) create_typography_section(width f32) {
 		style: vglyph.TextStyle{
 			font_name: 'Sans 24'
 			color:     color_text
+			size:      23
+			rise:      5
 			features:  &vglyph.FontFeatures{
 				opentype_features: [
 					vglyph.FontFeature{

--- a/layout.v
+++ b/layout.v
@@ -49,16 +49,134 @@ pub fn (mut ctx Context) layout_text(text string, cfg TextConfig) !Layout {
 		return Layout{}
 	}
 
-	// Defensive UTF-8 validation (API boundary validates, this is defense-in-depth)
-	validate_text_input(text, max_text_length, @FN)!
+	// Defensive validation (API boundary validates, this is defense-in-depth).
+	validate_layout_text_input(text, @FN)!
 
-	mut layout := setup_pango_layout(mut ctx, text, cfg) or {
+	markup_rise_pango := int(cfg.style.rise * ctx.scale_factor * pango_scale)
+	compose_markup_rise := cfg.use_markup && markup_rise_pango != 0
+	pango_cfg := if compose_markup_rise { config_without_base_rise(cfg) } else { cfg }
+	mut layout := setup_pango_layout(mut ctx, text, pango_cfg) or {
 		log.error('${@FILE_LINE}: ${err.msg()}')
 		return err
 	}
 	defer { layout.free() }
 
+	if compose_markup_rise {
+		compose_markup_style_rise(layout, markup_rise_pango)
+	}
 	return build_layout_from_pango(layout, text, ctx.scale_factor, cfg)
+}
+
+fn config_without_base_rise(cfg TextConfig) TextConfig {
+	return TextConfig{
+		...cfg
+		style: TextStyle{
+			...cfg.style
+			rise: 0
+		}
+	}
+}
+
+fn validate_layout_text_input(text string, location string) ! {
+	validate_text_input(text, max_text_length, location)!
+	for i in 0 .. text.len {
+		if text[i] == 0 {
+			return error('NUL byte not allowed at ${location}')
+		}
+	}
+}
+
+fn compose_markup_style_rise(layout PangoLayout, style_rise int) {
+	base_attrs := layout.get_attributes()
+	plain_text_ptr := C.pango_layout_get_text(layout.ptr)
+	plain_len := if plain_text_ptr == unsafe { nil } {
+		0
+	} else {
+		unsafe { cstring_to_vstring(plain_text_ptr).len }
+	}
+	if plain_len == 0 {
+		return
+	}
+
+	mut composed := new_pango_attr_list()
+	if base_attrs == unsafe { nil } {
+		insert_rise_attr(composed, 0, plain_len, style_rise)
+		layout.set_attributes(composed)
+		composed.free()
+		return
+	}
+
+	iter := C.pango_attr_list_get_iterator(base_attrs)
+	if iter == unsafe { nil } {
+		insert_rise_attr(composed, 0, plain_len, style_rise)
+		layout.set_attributes(composed)
+		composed.free()
+		return
+	}
+
+	for {
+		mut start := 0
+		mut end := 0
+		C.pango_attr_iterator_range(iter, &start, &end)
+		if start < 0 {
+			start = 0
+		}
+		if end < 0 || end > plain_len {
+			end = plain_len
+		}
+		if start < end {
+			markup_rise := copy_effective_attrs_without_rise(iter, composed, start, end)
+			insert_rise_attr(composed, start, end, style_rise + markup_rise)
+		}
+		if !C.pango_attr_iterator_next(iter) {
+			break
+		}
+	}
+	C.pango_attr_iterator_destroy(iter)
+	layout.set_attributes(composed)
+	composed.free()
+}
+
+fn copy_effective_attrs_without_rise(iter &C.PangoAttrIterator, attrs PangoAttrList, start int,
+	end int) int {
+	mut markup_rise := 0
+	mut attr_node := C.pango_attr_iterator_get_attrs(iter)
+	mut node := attr_node
+	for node != unsafe { nil } {
+		mut attr_copy := &C.PangoAttribute(unsafe { nil })
+		mut rise_delta := 0
+		unsafe {
+			attr := &C.PangoAttribute(node.data)
+			if attr.klass.type == .pango_attr_rise {
+				int_attr := &C.PangoAttrInt(attr)
+				rise_delta = int_attr.value
+			} else {
+				attr_copy = C.pango_attribute_copy(attr)
+			}
+			C.pango_attribute_destroy(attr)
+		}
+		markup_rise += rise_delta
+		if attr_copy != unsafe { nil } {
+			attr_copy.start_index = u32(start)
+			attr_copy.end_index = u32(end)
+			C.pango_attr_list_insert(attrs.ptr, attr_copy)
+		}
+		node = node.next
+	}
+	if attr_node != unsafe { nil } {
+		C.g_slist_free(attr_node)
+	}
+	return markup_rise
+}
+
+fn insert_rise_attr(attrs PangoAttrList, start int, end int, rise int) {
+	if rise == 0 || start >= end {
+		return
+	}
+	mut attr := C.pango_attr_rise_new(rise)
+	attr.start_index = u32(start)
+	attr.end_index = u32(end)
+	C.pango_attr_list_insert(attrs.ptr, attr)
 }
 
 // layout_rich_text layouts text with multiple styles (RichText).
@@ -79,9 +197,9 @@ pub fn (mut ctx Context) layout_rich_text(rt RichText, cfg TextConfig) !Layout {
 		return Layout{}
 	}
 
-	// Defensive validation of each run's text (defense-in-depth)
+	// Defensive validation of each run's text (defense-in-depth).
 	for run in rt.runs {
-		validate_text_input(run.text, max_text_length, @FN)!
+		validate_layout_text_input(run.text, @FN)!
 	}
 
 	// 1. Build Full Text and Calculate Indices
@@ -111,8 +229,10 @@ pub fn (mut ctx Context) layout_rich_text(rt RichText, cfg TextConfig) !Layout {
 
 	text := full_text.str()
 
-	// 2. Setup base layout with global config (font, align, wrap, base color)
-	mut layout := setup_pango_layout(mut ctx, text, cfg) or {
+	// 2. Setup base layout with global config. Rich text applies rise per run
+	// below so Pango geometry uses VGlyph's cumulative rise semantics.
+	pango_cfg := config_without_base_rise(cfg)
+	mut layout := setup_pango_layout(mut ctx, text, pango_cfg) or {
 		log.error('${@FILE_LINE}: ${err.msg()}')
 		return err
 	}
@@ -132,7 +252,10 @@ pub fn (mut ctx Context) layout_rich_text(rt RichText, cfg TextConfig) !Layout {
 	// Apply styles from runs
 	mut cloned_ids := []string{}
 	for run in valid_runs {
-		apply_rich_text_style(mut ctx, attr_list, run.style, run.start, run.end, mut cloned_ids)
+		effective_rise := cfg.style.rise + run.style.rise
+		effective_rise_pango := int(effective_rise * ctx.scale_factor * pango_scale)
+		apply_rich_text_style(mut ctx, attr_list, run.style, run.start, run.end,
+			effective_rise_pango, mut cloned_ids)
 	}
 
 	layout.set_attributes(attr_list)
@@ -208,6 +331,7 @@ fn build_layout_from_pango(layout PangoLayout, text string, scale_factor f32,
 
 	mut all_glyphs := []Glyph{}
 	mut items := []Item{}
+	line_rises := compute_line_rises(layout)
 
 	// Track cumulative vertical position for vertical text stacking
 	mut vertical_pen_y := match cfg.orientation {
@@ -238,6 +362,7 @@ fn build_layout_from_pango(layout PangoLayout, text string, scale_factor f32,
 				orientation:          cfg.orientation
 				stroke_width:         cfg.style.stroke_width
 				stroke_color:         cfg.style.stroke_color
+				line_rises:           line_rises
 			})
 		}
 
@@ -250,13 +375,13 @@ fn build_layout_from_pango(layout PangoLayout, text string, scale_factor f32,
 	mut char_rects := []CharRect{}
 	mut char_rect_by_index := map[int]int{}
 	if !cfg.no_hit_testing {
-		char_rects = compute_hit_test_rects(layout, text, scale_factor)
+		char_rects = compute_hit_test_rects(layout, text, scale_factor, line_rises, cfg.orientation)
 		// Build index map for O(1) lookup
 		for i, cr in char_rects {
 			char_rect_by_index[cr.index] = i
 		}
 	}
-	lines := compute_lines(layout, scale_factor)
+	lines := compute_lines(layout, scale_factor, line_rises, cfg.orientation)
 
 	ink_rect := C.PangoRectangle{}
 	logical_rect := C.PangoRectangle{}

--- a/layout_attributes.v
+++ b/layout_attributes.v
@@ -40,6 +40,7 @@ pub mut:
 	has_strikethrough bool
 	is_object         bool
 	object_id         string
+	rise              int
 }
 
 // parse_run_attributes extracts visual properties (color, decorations)
@@ -85,6 +86,10 @@ fn parse_run_attributes(pango_item &C.PangoItem) RunAttributes {
 				if int_attr.value != 0 {
 					attrs.has_strikethrough = true
 				}
+			} else if attr_type == .pango_attr_rise {
+				int_attr := &C.PangoAttrInt(attr)
+				// Pango can expose multiple active rise attributes for a run.
+				attrs.rise += int_attr.value
 			} else if attr_type == .pango_attr_shape {
 				shape_attr := &C.PangoAttrShape(attr)
 				if shape_attr.data != nil {
@@ -103,7 +108,7 @@ fn parse_run_attributes(pango_item &C.PangoItem) RunAttributes {
 // Caller retains ownership; this function only inserts attributes.
 // Attributes inserted become owned by the list (don't free them separately).
 fn apply_rich_text_style(mut ctx Context, list PangoAttrList, style TextStyle, start int,
-	end int, mut cloned_ids []string) {
+	end int, effective_rise_pango int, mut cloned_ids []string) {
 	// 1. Color
 	if style.color.a > 0 {
 		mut attr := C.pango_attr_foreground_new(u16(style.color.r) << 8, u16(style.color.g) << 8,
@@ -138,7 +143,15 @@ fn apply_rich_text_style(mut ctx Context, list PangoAttrList, style TextStyle, s
 		C.pango_attr_list_insert(list.ptr, attr)
 	}
 
-	// 5. Font Description (Name, Size, Typeface, Variations)
+	// 5. Baseline Rise
+	if effective_rise_pango != 0 {
+		mut attr := C.pango_attr_rise_new(effective_rise_pango)
+		attr.start_index = u32(start)
+		attr.end_index = u32(end)
+		C.pango_attr_list_insert(list.ptr, attr)
+	}
+
+	// 6. Font Description (Name, Size, Typeface, Variations)
 	// Set if font_name, size, or typeface is defined.
 	if style.font_name != '' || style.size > 0 || style.typeface != .regular {
 		mut desc := PangoFontDescription{}
@@ -195,7 +208,7 @@ fn apply_rich_text_style(mut ctx Context, list PangoAttrList, style TextStyle, s
 		}
 	}
 
-	// 6. OpenType Features
+	// 7. OpenType Features
 	if unsafe { style.features != nil } && style.features.opentype_features.len > 0 {
 		mut sb := strings.new_builder(64)
 		for i, f in style.features.opentype_features {
@@ -212,7 +225,7 @@ fn apply_rich_text_style(mut ctx Context, list PangoAttrList, style TextStyle, s
 		attr.end_index = u32(end)
 		C.pango_attr_list_insert(list.ptr, attr)
 	}
-	// 7. Letter Spacing
+	// 8. Letter Spacing
 	if style.letter_spacing != 0 {
 		spacing := int(style.letter_spacing * ctx.scale_factor * pango_scale)
 		mut ls := C.pango_attr_letter_spacing_new(spacing)
@@ -220,7 +233,7 @@ fn apply_rich_text_style(mut ctx Context, list PangoAttrList, style TextStyle, s
 		ls.end_index = u32(end)
 		C.pango_attr_list_insert(list.ptr, ls)
 	}
-	// 8. Inline Objects
+	// 9. Inline Objects
 	if unsafe { style.object != nil } {
 		obj := style.object
 		// Pango units

--- a/layout_iter.v
+++ b/layout_iter.v
@@ -10,6 +10,12 @@ pub mut:
 	strike_thick f64
 }
 
+struct LineRise {
+	start int
+	end   int
+	rise  int
+}
+
 // get_run_metrics fetches metrics (position, thickness) for active decorations
 // (underline, strikethrough) using Pango API.
 fn get_run_metrics(pango_font &C.PangoFont, language &C.PangoLanguage,
@@ -59,6 +65,65 @@ struct ProcessRunConfig {
 	orientation          TextOrientation
 	stroke_width         f32
 	stroke_color         gg.Color
+	line_rises           []LineRise
+}
+
+fn resolve_line_rise(start int, length int, ranges []LineRise, fallback int) int {
+	end := start + length
+	for rise_range in ranges {
+		if start < rise_range.end && end > rise_range.start {
+			return rise_range.rise
+		}
+	}
+	return fallback
+}
+
+fn resolve_line_rise_at(index int, ranges []LineRise) int {
+	for rise_range in ranges {
+		if index >= rise_range.start && index < rise_range.end {
+			return rise_range.rise
+		}
+	}
+	return 0
+}
+
+fn compute_line_rises(layout PangoLayout) []LineRise {
+	mut line_rises := []LineRise{}
+	mut iter := layout.get_iter()
+	if iter.is_nil() {
+		return line_rises
+	}
+	defer { iter.free() }
+
+	for {
+		line_ptr := C.pango_layout_iter_get_line_readonly(iter.ptr)
+		if line_ptr != unsafe { nil } {
+			mut found := false
+			mut max_rise := 0
+			mut run_node := line_ptr.runs
+			for run_node != unsafe { nil } {
+				unsafe {
+					run := &C.PangoLayoutRun(run_node.data)
+					attrs := parse_run_attributes(run.item)
+					if !found || attrs.rise > max_rise {
+						max_rise = attrs.rise
+						found = true
+					}
+					run_node = run_node.next
+				}
+			}
+			line_rises << LineRise{
+				start: line_ptr.start_index
+				end:   line_ptr.start_index + line_ptr.length
+				rise:  if found { max_rise } else { 0 }
+			}
+		}
+
+		if !C.pango_layout_iter_next_line(iter.ptr) {
+			break
+		}
+	}
+	return line_rises
 }
 
 // process_run converts a single Pango glyph run into a V `Item`.
@@ -104,7 +169,20 @@ fn process_run(mut items []Item, mut all_glyphs []Glyph, vertical_pen_y f64,
 
 	mut run_ascent := f64(ascent_pango) * pixel_scale
 	mut run_descent := f64(descent_pango) * pixel_scale
-	mut run_y := f64(baseline_pango) * pixel_scale
+	raw_run_y := f64(baseline_pango) * pixel_scale
+
+	rise_pango := attrs.rise
+	line_rise_pango := resolve_line_rise(pango_item.offset, pango_item.length, cfg.line_rises,
+		rise_pango)
+	rise := f64(rise_pango) * pixel_scale
+	line_rise := f64(line_rise_pango) * pixel_scale
+	// Pango shifts the line baseline by the maximum rise on that line. Normalize
+	// by the line rise, then apply this run's own visual rise exactly once below.
+	base_run_y := raw_run_y - line_rise
+	if rise != 0 {
+		run_ascent -= rise
+		run_descent += rise
+	}
 
 	// Emoji: override run metrics with primary text font
 	// metrics so GPU scaling matches text height.
@@ -178,14 +256,19 @@ fn process_run(mut items []Item, mut all_glyphs []Glyph, vertical_pen_y f64,
 	// Pango's run_y (horizontal baseline offset) maps to X centering.
 
 	line_height_run := cfg.primary_ascent + cfg.primary_descent
-	final_run_x, final_run_y, new_vertical_pen_y := match cfg.orientation {
+	final_run_x, run_position_y, new_vertical_pen_y := match cfg.orientation {
 		.horizontal {
-			compute_run_position_horizontal(run_x, run_y, vertical_pen_y)
+			compute_run_position_horizontal(run_x, base_run_y, vertical_pen_y)
 		}
 		.vertical {
-			compute_run_position_vertical(run_x, run_y, vertical_pen_y, line_height_run,
+			compute_run_position_vertical(run_x, base_run_y, vertical_pen_y, line_height_run,
 				glyph_count)
 		}
+	}
+
+	mut final_run_y := run_position_y
+	if rise != 0 {
+		final_run_y -= rise
 	}
 
 	// Get sub-text
@@ -256,7 +339,8 @@ fn process_run(mut items []Item, mut all_glyphs []Glyph, vertical_pen_y f64,
 
 // compute_hit_test_rects generates bounding boxes for every character
 // to enable efficient hit testing.
-fn compute_hit_test_rects(layout PangoLayout, text string, scale_factor f32) []CharRect {
+fn compute_hit_test_rects(layout PangoLayout, text string, scale_factor f32,
+	line_rises []LineRise, orientation TextOrientation) []CharRect {
 	mut char_rects := []CharRect{cap: text.len}
 
 	// Use iterator for O(N) traversal instead of O(N^2) with index_to_pos
@@ -297,6 +381,12 @@ fn compute_hit_test_rects(layout PangoLayout, text string, scale_factor f32) []C
 		mut final_y := f32(pos.y) * pixel_scale
 		mut final_w := f32(pos.width) * pixel_scale
 		mut final_h := f32(pos.height) * pixel_scale
+		// Vertical layout has its own run transform; do not adjust cached Pango
+		// extents there until char/line geometry is transformed as a whole.
+		line_rise_pango := resolve_line_rise_at(idx, line_rises)
+		if orientation == .horizontal && line_rise_pango != 0 {
+			final_y -= f32(line_rise_pango) * pixel_scale
+		}
 
 		if final_w < 0 {
 			final_x += final_w
@@ -330,7 +420,8 @@ fn compute_hit_test_rects(layout PangoLayout, text string, scale_factor f32) []C
 	return char_rects
 }
 
-fn compute_lines(layout PangoLayout, scale_factor f32) []Line {
+fn compute_lines(layout PangoLayout, scale_factor f32, line_rises []LineRise,
+	orientation TextOrientation) []Line {
 	line_count := C.pango_layout_get_line_count(layout.ptr)
 	mut lines := []Line{cap: line_count}
 	// Reset iterator to start
@@ -352,6 +443,13 @@ fn compute_lines(layout PangoLayout, scale_factor f32) []Line {
 			mut final_y := f32(rect.y) * pixel_scale
 			mut final_w := f32(rect.width) * pixel_scale
 			mut final_h := f32(rect.height) * pixel_scale
+			// Keep the mixed-rise normalization horizontal-only for the same
+			// reason as character extents above.
+			line_rise_pango :=
+				resolve_line_rise(line_ptr.start_index, line_ptr.length, line_rises, 0)
+			if orientation == .horizontal && line_rise_pango != 0 {
+				final_y -= f32(line_rise_pango) * pixel_scale
+			}
 
 			lines << Line{
 				start_index:        line_ptr.start_index

--- a/layout_pango.v
+++ b/layout_pango.v
@@ -97,6 +97,15 @@ fn setup_pango_layout(mut ctx Context, text string, cfg TextConfig) !PangoLayout
 			C.pango_attr_list_insert(attr_list.ptr, s_attr)
 		}
 
+		// Baseline Rise
+		if cfg.style.rise != 0 {
+			rise := int(cfg.style.rise * ctx.scale_factor * pango_scale)
+			mut r_attr := C.pango_attr_rise_new(rise)
+			r_attr.start_index = 0
+			r_attr.end_index = u32(C.G_MAXUINT)
+			C.pango_attr_list_insert(attr_list.ptr, r_attr)
+		}
+
 		// Letter Spacing
 		if cfg.style.letter_spacing != 0 {
 			spacing := int(cfg.style.letter_spacing * ctx.scale_factor * pango_scale)

--- a/layout_types.v
+++ b/layout_types.v
@@ -274,6 +274,7 @@ pub:
 	underline      bool
 	strikethrough  bool
 	letter_spacing f32 // Extra spacing between characters (points)
+	rise           f32 // Baseline shift in logical pixels; positive moves text up, negative moves it down
 
 	// Stroke (outline)
 	stroke_width f32 // Width in points (0 = no stroke)


### PR DESCRIPTION
## Summary

Adds baseline rise support to `vglyph` text styles.

This introduces `TextStyle.rise`, forwarded through both plain text and rich text layout, and backed by Pango `rise` attributes. Positive values move text up, negative values move text down.

## Why

This gives users and downstream modules a proper typed way to render superscript, subscript, and other baseline-shifted text without relying only on font-specific OpenType features.

This PR contributes to resolving v-gui [#51](https://github.com/vlang/gui/issues/51).

Codex review validation [here](https://github.com/GGRei/vglyph/pull/4)

## Changes

- Add `TextStyle.rise`.
- Apply rise in plain text and rich text style runs.
- Include rise in the plain layout cache key.
- Add tests for plain/rich rise layout behavior.
- Document the new style field and update the showcase.

## Validation

- `git diff --check`: passed.
- `_rise_test.v` is included in the existing root `*_test.v` CI discovery.
- Local `v test _rise_test.v` was attempted but is currently blocked by unrelated local V/Sokol/X11 type errors before project assertions.