### PR TITLE
text: fix clang pango pointer bindings

### DIFF
--- a/c_bindings.v
+++ b/c_bindings.v
@@ -259,6 +259,7 @@ pub const subpixel_bins = 4 // Number of subpixel bins (0, 0.25, 0.5, 0.75)
 
 #include <pango/pango.h>
 #include <pango/pangoft2.h>
+#include "pango_const_compat.h"
 #include <glib-object.h>
 #include <glib.h>
 
@@ -377,6 +378,12 @@ pub mut:
 
 @[typedef]
 pub struct C.PangoFontMap {}
+
+@[typedef]
+pub struct C.PangoFT2FontMap {}
+
+@[typedef]
+pub struct C.PangoFcFontMap {}
 
 @[typedef]
 pub struct C.PangoFont {}
@@ -583,7 +590,8 @@ pub const pango_glyph_unknown_flag = 0x10000000
 
 // Pango FT2
 fn C.pango_ft2_font_map_new() &C.PangoFontMap
-fn C.pango_ft2_font_map_set_resolution(&C.PangoFontMap, f64, f64)
+fn C.PANGO_FT2_FONT_MAP(&C.PangoFontMap) &C.PangoFT2FontMap
+fn C.pango_ft2_font_map_set_resolution(&C.PangoFT2FontMap, f64, f64)
 fn C.pango_font_map_create_context(&C.PangoFontMap) &C.PangoContext
 fn C.pango_ft2_font_get_face(&C.PangoFont) &C.FT_FaceRec
 
@@ -593,8 +601,8 @@ fn C.pango_layout_set_text(&C.PangoLayout, &char, int)
 fn C.pango_layout_set_markup(&C.PangoLayout, &char, int)
 fn C.pango_layout_set_font_description(&C.PangoLayout, &C.PangoFontDescription)
 fn C.pango_layout_get_iter(&C.PangoLayout) &C.PangoLayoutIter
-fn C.pango_layout_get_text(&C.PangoLayout) &char
-fn C.pango_layout_get_font_description(&C.PangoLayout) &C.PangoFontDescription
+fn C.vglyph_pango_layout_get_text_borrowed(&C.PangoLayout) &char
+fn C.vglyph_pango_layout_get_font_description_borrowed(&C.PangoLayout) &C.PangoFontDescription
 fn C.pango_layout_get_extents(&C.PangoLayout, &C.PangoRectangle, &C.PangoRectangle)
 fn C.pango_layout_index_to_pos(&C.PangoLayout, int, &C.PangoRectangle)
 
@@ -615,7 +623,7 @@ fn C.pango_font_description_new() &C.PangoFontDescription
 fn C.pango_font_description_from_string(&char) &C.PangoFontDescription
 fn C.pango_font_description_free(&C.PangoFontDescription)
 fn C.pango_font_description_to_string(&C.PangoFontDescription) &char
-fn C.pango_font_description_get_family(&C.PangoFontDescription) &char
+fn C.vglyph_pango_font_description_get_family_borrowed(&C.PangoFontDescription) &char
 fn C.pango_font_description_set_family(&C.PangoFontDescription, &char)
 fn C.pango_font_description_set_variations(&C.PangoFontDescription, &char)
 fn C.pango_font_description_get_variations(&C.PangoFontDescription) &char
@@ -733,7 +741,8 @@ fn C.FcConfigAppFontAddFile(config &C.FcConfig, file &char) C.FcBool
 fn C.FcConfigAppFontAddDir(config &C.FcConfig, dir &char) C.FcBool
 
 // PangoFc
-fn C.pango_fc_font_map_config_changed(voidptr)
+fn C.PANGO_FC_FONT_MAP(&C.PangoFontMap) &C.PangoFcFontMap
+fn C.pango_fc_font_map_config_changed(&C.PangoFcFontMap)
 
 // Pango LogAttr - Character classification for cursor positioning
 // C struct uses bitfields, V accesses them as u32 members (guint = u32)
@@ -761,7 +770,7 @@ pub:
 // Pango Cursor Functions
 fn C.pango_layout_get_cursor_pos(&C.PangoLayout, int, &C.PangoRectangle, &C.PangoRectangle)
 fn C.pango_layout_move_cursor_visually(&C.PangoLayout, bool, int, int, int, &int, &int)
-fn C.pango_layout_get_log_attrs_readonly(&C.PangoLayout, &int) &C.PangoLogAttr
+fn C.vglyph_pango_layout_get_log_attrs_readonly_borrowed(&C.PangoLayout, &int) &C.PangoLogAttr
 
 // Linux IME bridge C bindings
 $if linux {

--- a/context.v
+++ b/context.v
@@ -181,7 +181,8 @@ pub fn new_context(scale_factor f32) !&Context {
 	// Set default resolution to 72 DPI * scale_factor.
 	// This ensures that 1 pt == 1 px (logical).
 	safe_scale := if scale_factor > 0 { scale_factor } else { 1.0 }
-	C.pango_ft2_font_map_set_resolution(pango_font_map, 72.0 * safe_scale, 72.0 * safe_scale)
+	ft2_font_map := C.PANGO_FT2_FONT_MAP(pango_font_map)
+	C.pango_ft2_font_map_set_resolution(ft2_font_map, 72.0 * safe_scale, 72.0 * safe_scale)
 
 	pango_context := C.pango_font_map_create_context(pango_font_map)
 	if voidptr(pango_context) == unsafe { nil } {
@@ -208,7 +209,8 @@ pub fn new_context(scale_factor f32) !&Context {
 				C.FcConfigAppFontAddDir(config, &char(path.str))
 			}
 			// Trigger update
-			C.pango_fc_font_map_config_changed(pango_font_map)
+			fc_font_map := C.PANGO_FC_FONT_MAP(pango_font_map)
+			C.pango_fc_font_map_config_changed(fc_font_map)
 		}
 	}
 
@@ -257,7 +259,8 @@ pub fn (mut ctx Context) add_font_file(path string) ! {
 	if res != 1 {
 		return error('FcConfigAppFontAddFile() failed for "${path}" at ${@FILE}:${@LINE}')
 	}
-	C.pango_fc_font_map_config_changed(ctx.pango_font_map.ptr)
+	fc_font_map := C.PANGO_FC_FONT_MAP(ctx.pango_font_map.ptr)
+	C.pango_fc_font_map_config_changed(fc_font_map)
 }
 
 // font_height returns the total visual height (ascent + descent) of the font
@@ -413,7 +416,7 @@ pub fn (mut ctx Context) resolve_font_name(font_desc_str string) !string {
 	defer { desc.free() }
 
 	// Resolve aliases
-	fam_ptr := C.pango_font_description_get_family(desc.ptr)
+	fam_ptr := C.vglyph_pango_font_description_get_family_borrowed(desc.ptr)
 	fam := if fam_ptr != unsafe { nil } { unsafe { cstring_to_vstring(fam_ptr) } } else { '' }
 	resolved_fam := resolve_family_alias(fam)
 	C.pango_font_description_set_family(desc.ptr, resolved_fam.str)
@@ -449,7 +452,7 @@ pub fn resolve_font_alias(name string) string {
 	defer { desc.free() }
 
 	// Get the family name (comma separated list)
-	fam_ptr := C.pango_font_description_get_family(desc.ptr)
+	fam_ptr := C.vglyph_pango_font_description_get_family_borrowed(desc.ptr)
 	fam := if fam_ptr != unsafe { nil } { unsafe { cstring_to_vstring(fam_ptr) } } else { '' }
 
 	// Apply aliases
@@ -507,7 +510,7 @@ pub fn (mut ctx Context) create_font_description(style TextStyle) PangoFontDescr
 	}
 
 	// Resolve and set family aliases
-	fam_ptr := C.pango_font_description_get_family(desc.ptr)
+	fam_ptr := C.vglyph_pango_font_description_get_family_borrowed(desc.ptr)
 	fam := if fam_ptr != unsafe { nil } { unsafe { cstring_to_vstring(fam_ptr) } } else { '' }
 	resolved_fam := resolve_family_alias(fam)
 	C.pango_font_description_set_family(desc.ptr, resolved_fam.str)

--- a/layout.v
+++ b/layout.v
@@ -88,7 +88,7 @@ fn validate_layout_text_input(text string, location string) ! {
 
 fn compose_markup_style_rise(layout PangoLayout, style_rise int) {
 	base_attrs := layout.get_attributes()
-	plain_text_ptr := C.pango_layout_get_text(layout.ptr)
+	plain_text_ptr := C.vglyph_pango_layout_get_text_borrowed(layout.ptr)
 	plain_len := if plain_text_ptr == unsafe { nil } {
 		0
 	} else {
@@ -291,7 +291,7 @@ fn build_layout_from_pango(layout PangoLayout, text string, scale_factor f32,
 	mut primary_descent := f64(0)
 	mut primary_strike_pos := f64(0)
 	mut primary_strike_thick := f64(0)
-	font_desc := C.pango_layout_get_font_description(layout.ptr)
+	font_desc := C.vglyph_pango_layout_get_font_description_borrowed(layout.ptr)
 	if font_desc != unsafe { nil } {
 		// Create a temporary metrics context
 		ctx := C.pango_layout_get_context(layout.ptr)

--- a/layout_attributes.v
+++ b/layout_attributes.v
@@ -165,7 +165,7 @@ fn apply_rich_text_style(mut ctx Context, list PangoAttrList, style TextStyle, s
 		if !desc.is_nil() {
 			if style.font_name != '' {
 				// Resolve aliases (important for 'System Font')
-				fam_ptr := C.pango_font_description_get_family(desc.ptr)
+				fam_ptr := C.vglyph_pango_font_description_get_family_borrowed(desc.ptr)
 				fam := if fam_ptr != unsafe { nil } {
 					unsafe { cstring_to_vstring(fam_ptr) }
 				} else {

--- a/layout_iter.v
+++ b/layout_iter.v
@@ -353,7 +353,7 @@ fn compute_hit_test_rects(layout PangoLayout, text string, scale_factor f32,
 
 	// Calculate fallback width for zero-width spaces
 	pixel_scale := 1.0 / (f32(pango_scale) * scale_factor)
-	font_desc := C.pango_layout_get_font_description(layout.ptr)
+	font_desc := C.vglyph_pango_layout_get_font_description_borrowed(layout.ptr)
 	mut fallback_width := f32(0)
 	if font_desc != unsafe { nil } {
 		size_pango := C.pango_font_description_get_size(font_desc)
@@ -482,7 +482,7 @@ struct LogAttrResult {
 // Uses Pango iterator to properly handle multi-byte characters (emoji, CJK, etc).
 fn extract_log_attrs(layout PangoLayout, text string) LogAttrResult {
 	mut n_attrs := int(0)
-	attrs_ptr := C.pango_layout_get_log_attrs_readonly(layout.ptr, &n_attrs)
+	attrs_ptr := C.vglyph_pango_layout_get_log_attrs_readonly_borrowed(layout.ptr, &n_attrs)
 	if attrs_ptr == unsafe { nil } || n_attrs == 0 {
 		return LogAttrResult{}
 	}

--- a/pango_const_compat.h
+++ b/pango_const_compat.h
@@ -1,0 +1,23 @@
+#ifndef VGLYPH_PANGO_CONST_COMPAT_H
+#define VGLYPH_PANGO_CONST_COMPAT_H
+
+#include <pango/pango.h>
+
+/* Borrowed read-only pointers for V bindings; do not free or mutate. */
+static inline char* vglyph_pango_layout_get_text_borrowed(PangoLayout* layout) {
+	return (char*)pango_layout_get_text(layout);
+}
+
+static inline PangoFontDescription* vglyph_pango_layout_get_font_description_borrowed(PangoLayout* layout) {
+	return (PangoFontDescription*)pango_layout_get_font_description(layout);
+}
+
+static inline PangoLogAttr* vglyph_pango_layout_get_log_attrs_readonly_borrowed(PangoLayout* layout, int* n_attrs) {
+	return (PangoLogAttr*)pango_layout_get_log_attrs_readonly(layout, n_attrs);
+}
+
+static inline char* vglyph_pango_font_description_get_family_borrowed(const PangoFontDescription* desc) {
+	return (char*)pango_font_description_get_family(desc);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Fix vlang/gui#75


Fixes the Linux clang build failure caused by inaccurate Pango pointer bindings in `vglyph`.

The PangoFT2 API returns a generic `PangoFontMap*` from `pango_ft2_font_map_new()`, but FT2-specific calls such as `pango_ft2_font_map_set_resolution()` expect a `PangoFT2FontMap*`. The same applies to the FontConfig map path through `PangoFcFontMap*`.

This PR makes those boundaries explicit by:

- adding distinct `PangoFT2FontMap` and `PangoFcFontMap` bindings;
- using Pango's official `PANGO_FT2_FONT_MAP` and `PANGO_FC_FONT_MAP` casts at the narrow call sites;
- adding small borrowed/read-only Pango const-return wrappers for APIs that V cannot model as `const` pointers directly.

No warning suppression is added.

## Validation

- `v fmt -verify c_bindings.v context.v layout.v layout_iter.v layout_attributes.v`
- `v -no-parallel test .`
- `v -cc clang test .`
- `v -cc gcc test .`
- `v -no-parallel -cc clang -show-c-output -cflags '-Werror=incompatible-pointer-types' test _font_resource_test.v`
- `v -no-parallel -cc clang -show-c-output -cflags '-Werror=incompatible-pointer-types' test _font_height_test.v _layout_test.v`

[Codex validation](https://github.com/GGRei/vglyph/pull/5)

Also validated through a `gui` consumer smoke test using this local `vglyph` build:

- `VMODULES=/tmp/v_gui_issue75_modpath v -no-parallel -cc clang -show-c-output -cflags '-Werror=incompatible-pointer-types' test _text_test.v`